### PR TITLE
Remove duplicate/typo'd translation key

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -61,7 +61,6 @@
     "company": "Firma",
     "confirm_delete_address": "Sind Sie sicher, dass Sie diese Adresse löschen möchten?",
     "confirm_password": "Passwort bestätigen",
-    "confrim_password": "Passwort bestätigen",
     "contact": {
         "thanks": "Danke, dass Sie uns kontaktiert haben. Wir werden uns so schnell wie möglich bei Ihnen melden."
     },

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -61,7 +61,6 @@
     "company": "Company",
     "confirm_delete_address": "Are you sure you wish to delete this address?",
     "confirm_password": "Confirm Password",
-    "confrim_password": "Confirm password",
     "contact": {
         "thanks": "Thanks for contacting us. We'll get back to you as soon as possible."
     },

--- a/locales/es.json
+++ b/locales/es.json
@@ -61,7 +61,6 @@
     "company": "Compañía",
     "confirm_delete_address": "¿Está seguro de que desea eliminar esta dirección?",
     "confirm_password": "Confirmar contraseña",
-    "confrim_password": "Confirmar contraseña",
     "contact": {
         "thanks": "Gracias por contactarnos. Le responderemos lo antes posible."
     },

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -61,7 +61,6 @@
     "company": "Compagnie",
     "confirm_delete_address": "Êtes-vous certain(e) de vouloir supprimer cette adresse?",
     "confirm_password": "Confirmer le mot de passe",
-    "confrim_password": "Confirmer le mot de passe",
     "contact": {
         "thanks": "Merci de nous avoir avoir contacté. Nous vous reviendrons le plus rapidement possible."
     },

--- a/locales/it.json
+++ b/locales/it.json
@@ -61,7 +61,6 @@
     "company": "Azienda",
     "confirm_delete_address": "Desideri davvero eliminare questo indirizzo?",
     "confirm_password": "Conferma la password",
-    "confrim_password": "Conferma password",
     "contact": {
         "thanks": "Grazie per averci contattato. Risponderemo il prima possibile."
     },

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -61,7 +61,6 @@
     "company": "Empresa",
     "confirm_delete_address": "Deseja realmente excluir este endereço?",
     "confirm_password": "Confirmar senha",
-    "confrim_password": "Confirmar senha",
     "contact": {
         "thanks": "Obrigado por entrar em contato. Nós lhe retornaremos assim que possível."
     },

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -61,7 +61,6 @@
     "company": "Empresa",
     "confirm_delete_address": "Tem a certeza de que quer eliminar este endereço?",
     "confirm_password": "Confirmar Senha",
-    "confrim_password": "Confirmar Senha",
     "contact": {
         "thanks": "Obrigado por entrar em contacto connosco. Responder-lhe-emos logo que possível."
     },


### PR DESCRIPTION
Removes the `confrim_password` key from the locale files. Proper key is the one above it: `confirm_password`.