### PR TITLE
Removes size chart trigger locales

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -245,7 +245,6 @@
         "zip": "PLZ"
     },
     "trigger": {
-        "color_swatch": "Farbe",
-        "size": "Größe"
+        "color_swatch": "Farbe"
     }
 }

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -245,7 +245,6 @@
         "zip": "Postal/Zip code"
     },
     "trigger": {
-        "color_swatch": "Color",
-        "size": "Size"
+        "color_swatch": "Color"
     }
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -231,7 +231,7 @@
         "shipping": "Envío",
         "shipping_address": "Dirección de envío",
         "site_navigation": "Navegación",
-        "size_chart": "Tabla de tallas",
+        "size_chart": "Carta del tamaño",
         "sku": "SKU",
         "small": "Small",
         "subtotal": "Subtotal",
@@ -245,7 +245,6 @@
         "zip": "Código postal"
     },
     "trigger": {
-        "color_swatch": "Color",
-        "size": "Tamaño"
+        "color_swatch": "Color"
     }
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -245,7 +245,6 @@
         "zip": "Code postal"
     },
     "trigger": {
-        "color_swatch": "Couleur",
-        "size": "Taille"
+        "color_swatch": "Couleur"
     }
 }

--- a/locales/it.json
+++ b/locales/it.json
@@ -245,7 +245,6 @@
         "zip": "Codice postale"
     },
     "trigger": {
-        "color_swatch": "Colore",
-        "size": "Dimensioni"
+        "color_swatch": "Colore"
     }
 }

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -245,7 +245,6 @@
         "zip": "CEP"
     },
     "trigger": {
-        "color_swatch": "Cor",
-        "size": "Tamanho"
+        "color_swatch": "Cor"
     }
 }

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -245,7 +245,6 @@
         "zip": "Código Postal"
     },
     "trigger": {
-        "color_swatch": "Cor",
-        "size": "Tamanho"
+        "color_swatch": "Cor"
     }
 }


### PR DESCRIPTION
Removes size chart trigger and updates spanish locales to use proper translation (which will help properly trigger on spanish storefronts

Fixes https://github.com/archetype-themes/locales/issues/11