### PR TITLE
chore: include period in variant picker info

### DIFF
--- a/locales/de.schema.json
+++ b/locales/de.schema.json
@@ -190,7 +190,7 @@
     "use_instead_of_mapbox_api": "Verwenden Sie anstelle eines API-Zugriffstokens",
     "used_when_on_top_of_image": "Verwendet, wenn über einem Bild",
     "values_below_10_not_recommended": "Werte unter 10 Sekunden werden nicht empfohlen. Verzögerung im Editor deaktiviert.",
-    "variant_picker_display_options": "Zeigen Sie Produktoptionen als Schaltflächen und Farbfelder oder Dropdowns an. [Erfahren Sie, wie Sie Farbfelder einrichten](https://help.shopify.com/en/manual/custom-data/metafields/category-metafields/using-category-metafields).",
+    "variant_picker_display_options": "Zeigen Sie Produktoptionen als Schaltflächen und Farbfelder oder Dropdowns an. [Erfahren Sie, wie Sie Farbfelder einrichten.](https://help.shopify.com/en/manual/custom-data/metafields/category-metafields/using-category-metafields)",
     "video_with_sound_not_autoplay": "Video mit Ton wird nicht automatisch abgespielt"
   },
   "labels": {

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -190,7 +190,7 @@
     "use_instead_of_mapbox_api": "Use instead of an API access token",
     "used_when_on_top_of_image": "Used when on top of an image",
     "values_below_10_not_recommended": "Values below 10 seconds are not recommended. Delay disabled in the editor.",
-    "variant_picker_display_options": "Show product options as buttons and swatches or dropdowns. [Learn how to set up color swatches](https://help.shopify.com/en/manual/custom-data/metafields/category-metafields/using-category-metafields).",
+    "variant_picker_display_options": "Show product options as buttons and swatches or dropdowns. [Learn how to set up color swatches.](https://help.shopify.com/en/manual/custom-data/metafields/category-metafields/using-category-metafields)",
     "video_with_sound_not_autoplay": "Video with sound will not autoplay"
   },
   "labels": {

--- a/locales/es.schema.json
+++ b/locales/es.schema.json
@@ -190,7 +190,7 @@
     "use_instead_of_mapbox_api": "Usar en lugar de un token de acceso a la API",
     "used_when_on_top_of_image": "Utilizar cuando está encima de una imagen",
     "values_below_10_not_recommended": "No se recomiendan valores inferiores a 10 segundos. Retraso desactivado en el editor.",
-    "variant_picker_display_options": "Muestra las opciones de producto como botones y muestras o menús desplegables. [Aprende a configurar muestras de color](https://help.shopify.com/en/manual/custom-data/metafields/category-metafields/using-category-metafields).",
+    "variant_picker_display_options": "Muestra las opciones de producto como botones y muestras o menús desplegables. [Aprende a configurar muestras de color.](https://help.shopify.com/en/manual/custom-data/metafields/category-metafields/using-category-metafields)",
     "video_with_sound_not_autoplay": "El vídeo con sonido no se reproducirá de forma automática"
   },
   "labels": {

--- a/locales/fr.schema.json
+++ b/locales/fr.schema.json
@@ -190,7 +190,7 @@
     "use_instead_of_mapbox_api": "Utiliser à la place d’un jeton d’accès API",
     "used_when_on_top_of_image": "Utilisé lorsqu'il se trouve au-dessus d'une image",
     "values_below_10_not_recommended": "Le délai est désactivé dans l'éditeur de thème pour des raisons de visibilité",
-    "variant_picker_display_options": "Affichez les options du produit sous forme de boutons et d’échantillons ou de listes déroulantes. [Découvrez comment configurer des échantillons de couleurs](https://help.shopify.com/en/manual/custom-data/metafields/category-metafields/using-category-metafields).",
+    "variant_picker_display_options": "Affichez les options du produit sous forme de boutons et d’échantillons ou de listes déroulantes. [Découvrez comment configurer des échantillons de couleurs.](https://help.shopify.com/en/manual/custom-data/metafields/category-metafields/using-category-metafields)",
     "video_with_sound_not_autoplay": "La vidéo avec du son ne sera pas lue automatiquement"
   },
   "labels": {

--- a/locales/it.schema.json
+++ b/locales/it.schema.json
@@ -190,7 +190,7 @@
     "use_instead_of_mapbox_api": "Utilizzare al posto di un token di accesso API",
     "used_when_on_top_of_image": "Usato quando si trova sopra un'immagine",
     "values_below_10_not_recommended": "I valori inferiori a 10 secondi non sono raccomandati. Ritardo disabilitato nell'editor.",
-    "variant_picker_display_options": "Mostra le opzioni del prodotto come pulsanti e campioni o menu a discesa. [Scopri come impostare i campioni di colore](https://help.shopify.com/en/manual/custom-data/metafields/category-metafields/using-category-metafields).",
+    "variant_picker_display_options": "Mostra le opzioni del prodotto come pulsanti e campioni o menu a discesa. [Scopri come impostare i campioni di colore.](https://help.shopify.com/en/manual/custom-data/metafields/category-metafields/using-category-metafields)",
     "video_with_sound_not_autoplay": "I video sonori non verranno riprodotti automaticamente."
   },
   "labels": {


### PR DESCRIPTION
The period was breaking onto its own line when not part of the link.